### PR TITLE
Add validator support for RSS Update field

### DIFF
--- a/bssw-scripts.wpr
+++ b/bssw-scripts.wpr
@@ -1,0 +1,18 @@
+#!wing
+#!version=6.0
+##################################################################
+# Wing IDE project file                                          #
+##################################################################
+[project attributes]
+proj.directory-list = [{'dirloc': loc('.'),
+                        'excludes': (),
+                        'filter': u'*',
+                        'include_hidden': False,
+                        'recursive': True,
+                        'watch_for_changes': True}]
+proj.file-type = 'shared'
+proj.launch-config = {loc('test_article_metadata/validate_article.py'): ('pr'\
+        'oject',
+        (u'-s config-metadata.txt -f test_data/test_001_fail.md\n',
+         ''))}
+proj.main-file = loc('test_article_metadata/validate_article.py')

--- a/bssw-scripts.wpr
+++ b/bssw-scripts.wpr
@@ -13,6 +13,6 @@ proj.directory-list = [{'dirloc': loc('.'),
 proj.file-type = 'shared'
 proj.launch-config = {loc('test_article_metadata/validate_article.py'): ('pr'\
         'oject',
-        (u'-s config-metadata.txt -f test_data/test_001_fail.md\n',
+        (u'-s config-metadata.txt -f test_data/test_009_pass.md -D\n',
          ''))}
 proj.main-file = loc('test_article_metadata/validate_article.py')

--- a/test_article_metadata/checked_dictionary/checked_multivalue_dictionary.py
+++ b/test_article_metadata/checked_dictionary/checked_multivalue_dictionary.py
@@ -90,6 +90,7 @@ class checked_multivalue_dictionary(checked_dictionary):
         else:
             yield key
 
+
     def __gen_multikey_allowed_values__(self, tuple_depends_on, restrict_to_key, restrict_to_val):
         output = []
         for k in self.__gen_key_tuples__(tuple_depends_on):
@@ -130,33 +131,12 @@ class checked_multivalue_dictionary(checked_dictionary):
         return output
 
 
-
-    def __validate_data__(self, property_name, property_value, throw_error_on_fail=False):
-        """
-        Check a property against the restrictions.  Returns True if
-        the property is ok, False otherwise.
-        Set throw_error_on_fail if you want this to throw an error.
-
-        This method is treated as a private method... calling it directly might result
-        in unexpected failures.  For example, we don't check that self._data has been
-        created, so validating a property against an uninitialized instance will throw
-        errors.
-        """
+# Override the __validate_restrict_if_dep__ function for checking dependencies.
+    def __validate_restrict_if_dep__(self, property_name, property_value, throw_error_on_fail=False):
         output = True
-        restrict_to = self.get_restrict_to(property_name)
         restrict_if = self.get_restrict_if(property_name)
 
-        # restrict_to == None means there no immediate restrictions
-        if restrict_to is not None and str(property_value).lower() not in [str(value).lower() for value in restrict_to]:
-            output = False
-            if throw_error_on_fail is True:
-                msg  = ">>> '%s' is an invalid value for property '%s'.\n"%(property_value, property_name)
-                msg += ">>> Allowable values are:\n"
-                for r in restrict_to:
-                    msg += ">>> - '%s'\n"%(r)
-                raise ValueError, msg
-
-        elif restrict_if is not None:
+        if restrict_if is not None:
             dep_key = str(restrict_if["dep"])
             dep_val = self.get_property_value(dep_key)         # TODO: this needs to be checked for being a list...
 
@@ -184,7 +164,6 @@ class checked_multivalue_dictionary(checked_dictionary):
                     raise ValueError, msg
 
         return output
-
 
 
 
@@ -307,7 +286,6 @@ def __test_checked_multivalue_dictionary__():
         print "PASS - checked_multivalue_dictionary"
     else:
         print "FAIL - checked_multivalue_dictionary"
-
 
 
 

--- a/test_article_metadata/config-metadata.txt
+++ b/test_article_metadata/config-metadata.txt
@@ -109,4 +109,5 @@ R Aggregate, stand-alone and subresource
 
 ################################################################################
 # RSS Update
-N RSS Update 
+# DO: Date-Optional Format
+DO RSS Update

--- a/test_article_metadata/config-metadata.txt
+++ b/test_article_metadata/config-metadata.txt
@@ -107,3 +107,6 @@ R Aggregate, base
 R Aggregate, subresource
 R Aggregate, stand-alone and subresource
 
+################################################################################
+# RSS Update
+N RSS Update 

--- a/test_article_metadata/test_data/test_009_pass.md
+++ b/test_article_metadata/test_data/test_009_pass.md
@@ -1,0 +1,16 @@
+### Test Optional RSS Update metadata tag.
+
+This test file adds the optional `RSS Update: YYYY-MM-DD` tag to the metadata.
+
+
+
+<!---
+Publish: yes
+Categories: Planning, Reliability
+Topics: Testing, Debugging, Design
+Tags: training, webinar,
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2018-11-21
+--->

--- a/test_article_metadata/test_data/test_010_fail.md
+++ b/test_article_metadata/test_data/test_010_fail.md
@@ -2,7 +2,9 @@
 
 This test file adds the optional `RSS Update: YYYY-MM-DD` tag to the metadata.
 
-Date given will be a valid date: 2018-11-21
+Date given will be an invalid date: 2018-11-31
+
+
 
 <!---
 Publish: yes
@@ -12,5 +14,5 @@ Tags: training, webinar,
 Level: 2
 Prerequisites: defaults
 Aggregate: subresource
-RSS Update: 2018-11-21
+RSS Update: 2018-11-31
 --->

--- a/test_article_metadata/test_data/test_011_fail.md
+++ b/test_article_metadata/test_data/test_011_fail.md
@@ -2,7 +2,9 @@
 
 This test file adds the optional `RSS Update: YYYY-MM-DD` tag to the metadata.
 
-Date given will be a valid date: 2018-11-21
+Date given will be valid but improperly formatted date: 11-29-2018
+
+
 
 <!---
 Publish: yes
@@ -12,5 +14,5 @@ Tags: training, webinar,
 Level: 2
 Prerequisites: defaults
 Aggregate: subresource
-RSS Update: 2018-11-21
+RSS Update: 11-29-2018
 --->

--- a/test_article_metadata/test_data/test_012_fail.md
+++ b/test_article_metadata/test_data/test_012_fail.md
@@ -2,7 +2,8 @@
 
 This test file adds the optional `RSS Update: YYYY-MM-DD` tag to the metadata.
 
-Date given will be a valid date: 2018-11-21
+Date given will not be a date at all.
+
 
 <!---
 Publish: yes
@@ -12,5 +13,5 @@ Tags: training, webinar,
 Level: 2
 Prerequisites: defaults
 Aggregate: subresource
-RSS Update: 2018-11-21
+RSS Update: not_a_date
 --->


### PR DESCRIPTION
I added support to the validator for the `RSS Update` field.  

RSS Update is an optional field, and must be formatted as `YYYY-MM-DD`.

The checker will verify that the date is a valid date as well, so 2018-11-31 will fail since there is no 31st day of November.

I added some extra tests to the test_data to try various combinations of correct dates and bad dates, and re-ran the test suite to make sure that examples without the `RSS Update` field still pass / fail as expected.

FYI: @maherou @curfman 	