### PR TITLE
Bugfix: Badly formed lines in metadata handline.

### DIFF
--- a/bssw-scripts.wpr
+++ b/bssw-scripts.wpr
@@ -13,6 +13,6 @@ proj.directory-list = [{'dirloc': loc('.'),
 proj.file-type = 'shared'
 proj.launch-config = {loc('test_article_metadata/validate_article.py'): ('pr'\
         'oject',
-        (u'-s config-metadata.txt -f test_data/test_009_pass.md -D\n',
+        (u'-s config-metadata.txt -f test_data/test_pr_0344.md -D\n',
          ''))}
 proj.main-file = loc('test_article_metadata/validate_article.py')

--- a/test_article_metadata/metadata_validation_core.py
+++ b/test_article_metadata/metadata_validation_core.py
@@ -108,7 +108,19 @@ def tokenize_metadata(metadata_file_lines, program_options):
     """
     metadata_token_list = []
     for line in metadata_file_lines:
-        key,value_list = re.split(":", line, maxsplit=1)
+        line=line.strip()
+        # Skip empty lines because there won't be any key / value pairs on them.
+        if len(line) == 0:
+            continue
+        try:
+            key,value_list = re.split(":", line, maxsplit=1)
+        except:
+            print "Error: Failed to splt the metadata line: '%s'"%(line)
+            print "       Most likely this is because the line is not properly"
+            print "       formed as a 'key:value(,value)*' style line."
+            print "       Please check that the separator is a ':' character."
+            raise ValueError("Failed to split the metadata line: '%s'"%(line) )
+
         key = key.strip()
         for v in value_list.split(","):
             v = v.strip()

--- a/test_article_metadata/test_data/test_pr_0344.md
+++ b/test_article_metadata/test_data/test_pr_0344.md
@@ -1,0 +1,21 @@
+# Sample Title
+
+This example metadata section mimics the error from PR #344 where the empty line caused
+a traceback.
+
+The non `key:value` pair entry `Image owned or licensed by Sandia` also causes a problem that
+should be addressed.
+
+
+<!---
+Publish: preview
+Categories: reliability, development
+Topics: testing, continuous integration testing, documentation
+Tags: bssw-blog-article
+Level: 2
+Prerequisites: default
+Aggregate: none
+
+SAND #: SAND2019-4553 S
+Image owned or licensed by Sandia
+--->

--- a/test_article_metadata/test_gitdiff_example.sh
+++ b/test_article_metadata/test_gitdiff_example.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
-validate_gitdiff_statfile.py -f test_data/___git_changes.txt -s config-metadata.txt -p config-package-list.csv -V --color=tty
+validate_gitdiff_statfile.py \
+    -f test_data/___git_changes.txt \
+    -s config-metadata.txt \
+    -p config-package-list.csv \
+    -V --color=tty
 
 


### PR DESCRIPTION
Addresses PR #244 from the BSSW repository.
https://github.com/betterscientificsoftware/betterscientificsoftware.github.io/pull/344

An empty line in the metadata caused an exception.
- The fix is to just skip empty lines in metadata

Metadata lines with no ":" and thus not separable into a `<key>:<value>`
style pair are still problematic, but I'm adding in some exception
handling to that line splitter to at least print out the line that
caused the segfault and an error message.

Going forward we will need to determine how to handle "comment" lines in
the metadata.

FYI: @curfman 