### PR TITLE
WIP: Adding requested features

### DIFF
--- a/bssw-scripts.wpr
+++ b/bssw-scripts.wpr
@@ -13,6 +13,6 @@ proj.directory-list = [{'dirloc': loc('.'),
 proj.file-type = 'shared'
 proj.launch-config = {loc('test_article_metadata/validate_article.py'): ('pr'\
         'oject',
-        (u'-s config-metadata.txt -f test_data/test_pr_0344.md -D\n',
+        (u'-V -s config-metadata.txt -f test_data/test_issue-03_02.md\n',
          ''))}
 proj.main-file = loc('test_article_metadata/validate_article.py')

--- a/bssw-scripts.wpr
+++ b/bssw-scripts.wpr
@@ -13,6 +13,6 @@ proj.directory-list = [{'dirloc': loc('.'),
 proj.file-type = 'shared'
 proj.launch-config = {loc('test_article_metadata/validate_article.py'): ('pr'\
         'oject',
-        (u'-V -s config-metadata.txt -f test_data/test_issue-03_02.md\n',
+        (u'-V -s config-metadata.txt -f test_data/test_issue-03_02xx.md\n',
          ''))}
 proj.main-file = loc('test_article_metadata/validate_article.py')

--- a/test_article_metadata/config-metadata.txt
+++ b/test_article_metadata/config-metadata.txt
@@ -39,6 +39,10 @@ D Topics,Categories,Planning,Design
 D Topics,Categories,Planning,Software interoperability
 
 # Deprecated
+# Note: Improving productivity and sustainability is planned to be 
+#       deprecated but there are no 'replacement' topics defined (yet).
+#       This could pose an issue if there are articles that use this
+#       topic only since we don't have a replacement defined.
 D Topics,Categories,Planning,Improving productivity and sustainability
 
 # New

--- a/test_article_metadata/config-metadata.txt
+++ b/test_article_metadata/config-metadata.txt
@@ -23,6 +23,7 @@
 # Publish
 R Publish, yes
 R Publish, no
+R Publish, preview
 
 
 ################################################################################

--- a/test_article_metadata/config-metadata.txt
+++ b/test_article_metadata/config-metadata.txt
@@ -67,14 +67,13 @@ D Topics,Categories,Development,Programming tools
 
 ########################################
 # Topics (Categories = Performance)
+D Topics,Categories,Performance,High-performance computing (HPC)
 D Topics,Categories,Performance,Performance portability
 
 # Deprecated
-D Topics,Categories,Performance,High-performance computing (HPC)
 D Topics,Categories,Performance,Performance at leadership computing facilities (LCFs)
 
 # New
-D Topics,Categories,Performance,High performance computing (HPC)
 D Topics,Categories,Performance,Performance at leadership computing facilities
 
 

--- a/test_article_metadata/config-metadata.txt
+++ b/test_article_metadata/config-metadata.txt
@@ -34,29 +34,48 @@ R Publish, preview
 
 ########################################
 # Topics (Categories = Planning)
-D Topics,Categories,Planning,Improving productivity and sustainability
 D Topics,Categories,Planning,Requirements
 D Topics,Categories,Planning,Design
 D Topics,Categories,Planning,Software interoperability
+
+# Deprecated
+D Topics,Categories,Planning,Improving productivity and sustainability
+
+# New
+D Topics,Categories,Planning,Software engineering
 
 
 ########################################
 # Topics (Categories = Development)
 D Topics,Categories,Development,Documentation
-D Topics,Categories,Development,Version control
 D Topics,Categories,Development,Configuration and builds
-D Topics,Categories,Development,Deployment
 D Topics,Categories,Development,Issue tracking
 D Topics,Categories,Development,Refactoring
+
+# Deprecated
 D Topics,Categories,Development,Software engineering
+D Topics,Categories,Development,Version control
+D Topics,Categories,Development,Deployment
 D Topics,Categories,Development,Development tools
+
+# New
+D Topics,Categories,Development,Revision control
+D Topics,Categories,Development,Software release and deployment
+D Topics,Categories,Development,Scientific programming languages
+D Topics,Categories,Development,Programming tools
 
 
 ########################################
 # Topics (Categories = Performance)
+D Topics,Categories,Performance,Performance portability
+
+# Deprecated
 D Topics,Categories,Performance,High-performance computing (HPC)
 D Topics,Categories,Performance,Performance at leadership computing facilities (LCFs)
-D Topics,Categories,Performance,Performance portability
+
+# New
+D Topics,Categories,Performance,High performance computing (HPC)
+D Topics,Categories,Performance,Performance at leadership computing facilities
 
 
 ########################################
@@ -74,13 +93,23 @@ D Topics,Categories,Collaboration,Strategies for more effective teams
 D Topics,Categories,Collaboration,Funding sources and programs
 D Topics,Categories,Collaboration,Projects and organizations
 D Topics,Categories,Collaboration,Software publishing and citation
-D Topics,Categories,Collaboration,Discussion forums, Q&A sites
+
+# Deprecated
+D Topics,Categories,Collaboration,Discussion forums Q&A sites
+
+# New
+D Topics,Categories,Collaboration,Discussion and question sites
+D Topics,Categories,Collaboration,Conferences and workshops
 
 
 ########################################
 # Topics (Categories = Skills)
-D Topics,Categories,Skills,Personal productivity and sustainability
 D Topics,Categories,Skills,Online learning
+D Topics,Categories,Skills,Personal productivity and sustainability
+
+# Deprecated
+
+# New
 
 
 ################################################################################

--- a/test_article_metadata/metadata_validation_core.py
+++ b/test_article_metadata/metadata_validation_core.py
@@ -98,12 +98,12 @@ def tokenize_metadata(metadata_file_lines, program_options):
         # Skip empty lines because there won't be any key / value pairs on them.
         if len(line) == 0:
             continue
-        # Skip the special case line that contains the "BSSw Metadata" descriptor.
+        # Skip the special case line that contains the "BSSw Metadata:" descriptor.
         # Since this should always be the first line in the updated ruleset, we
         # could just slice the list to metadata_file_lines[1:] but for consistency
         # I'll put in the check here.
         # TODO: Set this up as a parameter in the configuration file for genericity.
-        if line == "BSSw Metadata":
+        if line == "BSSw Metadata:":
             continue
 
         # The line should be a key:value pair, so let's split on the ":".
@@ -195,14 +195,14 @@ def is_metadata_section(line_list, program_options):
     """
     output = False
 
-    if re.match(r"^BSSw Metadata$", line_list[0]) is not None:
+    if re.match(r"^BSSw Metadata:$", line_list[0]) is not None:
         output = True
     else:
         # DEPRECATION WARNING: This method will be deprecated in the future in favor
-        # of looking for the BSSw Metadata tag.
+        # of looking for the `BSSw Metadata:` tag.
         for line in line_list:
             if re.match(r"^Publish:", line) is not None:
-                print_message("WARNING: The metadata section should have 'BSSw Metadata' as its first line.\n" +
+                print_message("WARNING: The metadata section should have `BSSw Metadata:` as its first line.\n" +
                               "         We didn't find that here but did detect the 'Publish: [yes|no|preview]'\n" +
                               "         key:value pair so we will guess that this is the metadata section.\n" +
                               "         This behavior will be DEPRECATED in the future."

--- a/test_article_metadata/metadata_validation_core.py
+++ b/test_article_metadata/metadata_validation_core.py
@@ -231,8 +231,8 @@ def check_metadata_in_file_lines(md_file, specfile_data, program_options):
     except EOFError, msg:
         output_passed  = False
         output_failmsg = msg
-        print_verbose("WARNING:", program_options)
-        print_verbose(msg, program_options)
+        print_warning("WARNING:", program_options)
+        print_warning(msg, program_options)
         # return output_passed, output_failmsg
 
     # If there's no metadata section...
@@ -260,8 +260,19 @@ def check_metadata_in_file(filename, specfile_data, program_options):
     print_debug("Check metadata for '%s': "%(filename), program_options)
     output_passed  = True
     output_failmsg = ""
-    md_file = markdown_file(filename, program_options)
-    output_passed,output_failmsg = check_metadata_in_file_lines(md_file, specfile_data, program_options)
+
+    try:
+        md_file = markdown_file(filename, program_options)
+    except IOError, msg:
+        print_error("An error occurred loading the file, '%s'"%(filename), program_options)
+        print_error("Error message:", program_options)
+        print_error(msg, program_options)
+        output_passed=False
+        output_failmsg=msg
+
+    if output_passed is not False:
+        output_passed,output_failmsg = check_metadata_in_file_lines(md_file, specfile_data, program_options)
+
     return output_passed,output_failmsg
 
 

--- a/test_article_metadata/test_data/test_001_fail.md
+++ b/test_article_metadata/test_data/test_001_fail.md
@@ -7,7 +7,7 @@
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_001_fail.md
+++ b/test_article_metadata/test_data/test_001_fail.md
@@ -7,6 +7,7 @@
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_002_pass.md
+++ b/test_article_metadata/test_data/test_002_pass.md
@@ -7,7 +7,7 @@
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_002_pass.md
+++ b/test_article_metadata/test_data/test_002_pass.md
@@ -7,6 +7,7 @@
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_003_pass.md
+++ b/test_article_metadata/test_data/test_003_pass.md
@@ -5,7 +5,7 @@ the metadata comment is never 'closed off', so the website should not actually p
 this since it, theoretically, wouldn't have the comment to work with.
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_003_pass.md
+++ b/test_article_metadata/test_data/test_003_pass.md
@@ -5,6 +5,7 @@ the metadata comment is never 'closed off', so the website should not actually p
 this since it, theoretically, wouldn't have the comment to work with.
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_004_pass.md
+++ b/test_article_metadata/test_data/test_004_pass.md
@@ -6,7 +6,7 @@ tag and thus shouldn't actually publish this.  It's effecitvely the same as a fi
 metadata section
 
 
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_004_pass.md
+++ b/test_article_metadata/test_data/test_004_pass.md
@@ -6,6 +6,7 @@ tag and thus shouldn't actually publish this.  It's effecitvely the same as a fi
 metadata section
 
 
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_005_pass.md
+++ b/test_article_metadata/test_data/test_005_pass.md
@@ -1,4 +1,5 @@
-# test_004_pass
+`test_004_pass`
+==============
 
 This test document will 'pass' the acceptance test because there is no 'metadata' section at all.
 

--- a/test_article_metadata/test_data/test_006_pass.md
+++ b/test_article_metadata/test_data/test_006_pass.md
@@ -7,7 +7,7 @@ This is a regular comment.
 This test should 'pass' because the metadata checks out and the initial comment (above) is just a comment but isn't the metadata comment.
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_006_pass.md
+++ b/test_article_metadata/test_data/test_006_pass.md
@@ -7,6 +7,7 @@ This is a regular comment.
 This test should 'pass' because the metadata checks out and the initial comment (above) is just a comment but isn't the metadata comment.
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_007_pass.md
+++ b/test_article_metadata/test_data/test_007_pass.md
@@ -4,7 +4,7 @@ This test should 'pass' the auto testing because it's not intended to be publish
 the metadata will be performed.
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: no
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_007_pass.md
+++ b/test_article_metadata/test_data/test_007_pass.md
@@ -4,6 +4,7 @@ This test should 'pass' the auto testing because it's not intended to be publish
 the metadata will be performed.
 
 <!---
+BSSw Metadata
 Publish: no
 Categories: Planning, Reliability, Collaboration, Crosscutting, Performance
 Topics: improving productivity and sustainability, reproducibility, testing, continuous integration testing, documentation

--- a/test_article_metadata/test_data/test_008_pass.md
+++ b/test_article_metadata/test_data/test_008_pass.md
@@ -5,6 +5,7 @@ Simple test that should pass.  Single line comments should be ok.
 <!--- single line comment --->
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_008_pass.md
+++ b/test_article_metadata/test_data/test_008_pass.md
@@ -5,7 +5,7 @@ Simple test that should pass.  Single line comments should be ok.
 <!--- single line comment --->
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_009_pass.md
+++ b/test_article_metadata/test_data/test_009_pass.md
@@ -5,7 +5,7 @@ This test file adds the optional `RSS Update: YYYY-MM-DD` tag to the metadata.
 Date given will be a valid date: 2018-11-21
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_009_pass.md
+++ b/test_article_metadata/test_data/test_009_pass.md
@@ -5,6 +5,7 @@ This test file adds the optional `RSS Update: YYYY-MM-DD` tag to the metadata.
 Date given will be a valid date: 2018-11-21
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_010_fail.md
+++ b/test_article_metadata/test_data/test_010_fail.md
@@ -7,7 +7,7 @@ Date given will be an invalid date: 2018-11-31
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_010_fail.md
+++ b/test_article_metadata/test_data/test_010_fail.md
@@ -7,6 +7,7 @@ Date given will be an invalid date: 2018-11-31
 
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_011_fail.md
+++ b/test_article_metadata/test_data/test_011_fail.md
@@ -7,6 +7,7 @@ Date given will be valid but improperly formatted date: 11-29-2018
 
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_011_fail.md
+++ b/test_article_metadata/test_data/test_011_fail.md
@@ -7,7 +7,7 @@ Date given will be valid but improperly formatted date: 11-29-2018
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_012_fail.md
+++ b/test_article_metadata/test_data/test_012_fail.md
@@ -6,7 +6,7 @@ Date given will not be a date at all.
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_012_fail.md
+++ b/test_article_metadata/test_data/test_012_fail.md
@@ -6,6 +6,7 @@ Date given will not be a date at all.
 
 
 <!---
+BSSw Metadata
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_013_pass_category_development.md
+++ b/test_article_metadata/test_data/test_013_pass_category_development.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Development
 Topics: Documentation, Configuration and builds, Revision Control, Software Release and Deployment, Issue Tracking, Scientific Programming Languages, Programming Tools, Refactoring

--- a/test_article_metadata/test_data/test_013_pass_category_development.md
+++ b/test_article_metadata/test_data/test_013_pass_category_development.md
@@ -11,7 +11,7 @@ PASS
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Development
 Topics: Documentation, Configuration and builds, Revision Control, Software Release and Deployment, Issue Tracking, Scientific Programming Languages, Programming Tools, Refactoring

--- a/test_article_metadata/test_data/test_013_pass_category_development.md
+++ b/test_article_metadata/test_data/test_013_pass_category_development.md
@@ -1,0 +1,22 @@
+Test Better Development Topics
+==============================
+
+Purpose
+-------
+Test the topics associated with the `Better Development Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Development
+Topics: Documentation, Configuration and builds, Revision Control, Software Release and Deployment, Issue Tracking, Scientific Programming Languages, Programming Tools, Refactoring
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_014_pass_category_development_deprecated.md
+++ b/test_article_metadata/test_data/test_014_pass_category_development_deprecated.md
@@ -1,0 +1,22 @@
+Test Better Development Topics
+==============================
+
+Purpose
+-------
+Test the deprecated topics associated with the `Better Development Topics` category
+
+Expected Result
+---------------
+PASS  (for now, once we deprecate things, this should fail)
+
+
+<!---
+Publish: preview
+Categories: Development
+Topics: Documentation, Version control, Configuration and builds, Deployment, Issue tracking, Refactoring, Software engineering, Development tools
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_014_pass_category_development_deprecated.md
+++ b/test_article_metadata/test_data/test_014_pass_category_development_deprecated.md
@@ -11,6 +11,7 @@ PASS  (for now, once we deprecate things, this should fail)
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Development
 Topics: Documentation, Version control, Configuration and builds, Deployment, Issue tracking, Refactoring, Software engineering, Development tools

--- a/test_article_metadata/test_data/test_014_pass_category_development_deprecated.md
+++ b/test_article_metadata/test_data/test_014_pass_category_development_deprecated.md
@@ -11,7 +11,7 @@ PASS  (for now, once we deprecate things, this should fail)
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Development
 Topics: Documentation, Version control, Configuration and builds, Deployment, Issue tracking, Refactoring, Software engineering, Development tools

--- a/test_article_metadata/test_data/test_015_pass_category_planning.md
+++ b/test_article_metadata/test_data/test_015_pass_category_planning.md
@@ -1,0 +1,22 @@
+Test Better Planning Topics
+===========================
+
+Purpose
+-------
+Test the topics associated with the `Better Planning Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Planning
+Topics: Software engineering, Requirements, Design, Software interoperability
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_015_pass_category_planning.md
+++ b/test_article_metadata/test_data/test_015_pass_category_planning.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Planning
 Topics: Software engineering, Requirements, Design, Software interoperability

--- a/test_article_metadata/test_data/test_015_pass_category_planning.md
+++ b/test_article_metadata/test_data/test_015_pass_category_planning.md
@@ -11,7 +11,7 @@ PASS
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Planning
 Topics: Software engineering, Requirements, Design, Software interoperability

--- a/test_article_metadata/test_data/test_016_pass_category_planning_deprecated.md
+++ b/test_article_metadata/test_data/test_016_pass_category_planning_deprecated.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Planning
 Topics: Improving productivity and sustainability, Requirements, Design, Software interoperability

--- a/test_article_metadata/test_data/test_016_pass_category_planning_deprecated.md
+++ b/test_article_metadata/test_data/test_016_pass_category_planning_deprecated.md
@@ -11,7 +11,7 @@ PASS
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Planning
 Topics: Improving productivity and sustainability, Requirements, Design, Software interoperability

--- a/test_article_metadata/test_data/test_016_pass_category_planning_deprecated.md
+++ b/test_article_metadata/test_data/test_016_pass_category_planning_deprecated.md
@@ -1,0 +1,22 @@
+Test Better Planning Topics
+===========================
+
+Purpose
+-------
+Test the topics associated with the `Better Planning Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Planning
+Topics: Improving productivity and sustainability, Requirements, Design, Software interoperability
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_017_pass_category_performance.md
+++ b/test_article_metadata/test_data/test_017_pass_category_performance.md
@@ -13,7 +13,7 @@ PASS
 <!---
 Publish: preview
 Categories: Performance
-Topics: High performance computing (HPC), Performance at leadership computing facilities, Performance portability
+Topics: High-performance computing (HPC), Performance at leadership computing facilities, Performance portability
 Tags: training
 Level: 2
 Prerequisites: defaults

--- a/test_article_metadata/test_data/test_017_pass_category_performance.md
+++ b/test_article_metadata/test_data/test_017_pass_category_performance.md
@@ -1,0 +1,22 @@
+Test Better Performance Topics
+==============================
+
+Purpose
+-------
+Test the topics associated with the `Better Performance Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Performance
+Topics: High performance computing (HPC), Performance at leadership computing facilities, Performance portability
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_017_pass_category_performance.md
+++ b/test_article_metadata/test_data/test_017_pass_category_performance.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata:
 Publish: preview
 Categories: Performance
 Topics: High-performance computing (HPC), Performance at leadership computing facilities, Performance portability

--- a/test_article_metadata/test_data/test_018_pass_category_performance_deprecated.md
+++ b/test_article_metadata/test_data/test_018_pass_category_performance_deprecated.md
@@ -11,6 +11,7 @@ PASS (until deprecations happen)
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Performance
 Topics: High-performance computing (HPC), Performance at leadership computing facilities (LCFs), Performance portability

--- a/test_article_metadata/test_data/test_018_pass_category_performance_deprecated.md
+++ b/test_article_metadata/test_data/test_018_pass_category_performance_deprecated.md
@@ -11,7 +11,7 @@ PASS (until deprecations happen)
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Performance
 Topics: High-performance computing (HPC), Performance at leadership computing facilities (LCFs), Performance portability

--- a/test_article_metadata/test_data/test_018_pass_category_performance_deprecated.md
+++ b/test_article_metadata/test_data/test_018_pass_category_performance_deprecated.md
@@ -1,0 +1,22 @@
+Test Better Performance Topics
+==============================
+
+Purpose
+-------
+Test the topics associated with the `Better Performance Topics` category
+
+Expected Result
+---------------
+PASS (until deprecations happen)
+
+
+<!---
+Publish: preview
+Categories: Performance
+Topics: High-performance computing (HPC), Performance at leadership computing facilities (LCFs), Performance portability
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_019_pass_category_reliability.md
+++ b/test_article_metadata/test_data/test_019_pass_category_reliability.md
@@ -1,0 +1,22 @@
+Test Better Reliability Topics
+==============================
+
+Purpose
+-------
+Test the topics associated with the `Better Reliability Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Reliability
+Topics: Testing, Continuous integration testing, Reproducibility, Debugging
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_019_pass_category_reliability.md
+++ b/test_article_metadata/test_data/test_019_pass_category_reliability.md
@@ -11,7 +11,7 @@ PASS
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Reliability
 Topics: Testing, Continuous integration testing, Reproducibility, Debugging

--- a/test_article_metadata/test_data/test_019_pass_category_reliability.md
+++ b/test_article_metadata/test_data/test_019_pass_category_reliability.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Reliability
 Topics: Testing, Continuous integration testing, Reproducibility, Debugging

--- a/test_article_metadata/test_data/test_020_pass_category_collaboration.md
+++ b/test_article_metadata/test_data/test_020_pass_category_collaboration.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Collaboration
 Topics: Projects and organizations, Strategies for more effective teams, Funding sources and programs, Software publishing and citation, Licensing, Discussion and question sites, Conferences and workshops

--- a/test_article_metadata/test_data/test_020_pass_category_collaboration.md
+++ b/test_article_metadata/test_data/test_020_pass_category_collaboration.md
@@ -11,7 +11,7 @@ PASS
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Collaboration
 Topics: Projects and organizations, Strategies for more effective teams, Funding sources and programs, Software publishing and citation, Licensing, Discussion and question sites, Conferences and workshops

--- a/test_article_metadata/test_data/test_020_pass_category_collaboration.md
+++ b/test_article_metadata/test_data/test_020_pass_category_collaboration.md
@@ -1,0 +1,22 @@
+Test Better Collaboration Topics
+================================
+
+Purpose
+-------
+Test the topics associated with the `Better Collaboration Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Collaboration
+Topics: Projects and organizations, Strategies for more effective teams, Funding sources and programs, Software publishing and citation, Licensing, Discussion and question sites, Conferences and workshops
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_021_pass_category_collaboration_deprecated.md
+++ b/test_article_metadata/test_data/test_021_pass_category_collaboration_deprecated.md
@@ -11,7 +11,7 @@ PASS (for now, until deprecations are done)
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Collaboration
 Topics: Licensing, Strategies for more effective teams, Funding sources and programs, Projects and organizations, Software publishing and citation, Discussion forums Q&A sites

--- a/test_article_metadata/test_data/test_021_pass_category_collaboration_deprecated.md
+++ b/test_article_metadata/test_data/test_021_pass_category_collaboration_deprecated.md
@@ -1,0 +1,22 @@
+Test Better Collaboration Topics
+================================
+
+Purpose
+-------
+Test the topics associated with the `Better Collaboration Topics` category
+
+Expected Result
+---------------
+PASS (for now, until deprecations are done)
+
+
+<!---
+Publish: preview
+Categories: Collaboration
+Topics: Licensing, Strategies for more effective teams, Funding sources and programs, Projects and organizations, Software publishing and citation, Discussion forums Q&A sites
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_021_pass_category_collaboration_deprecated.md
+++ b/test_article_metadata/test_data/test_021_pass_category_collaboration_deprecated.md
@@ -11,6 +11,7 @@ PASS (for now, until deprecations are done)
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Collaboration
 Topics: Licensing, Strategies for more effective teams, Funding sources and programs, Projects and organizations, Software publishing and citation, Discussion forums Q&A sites

--- a/test_article_metadata/test_data/test_022_pass_category_skills.md
+++ b/test_article_metadata/test_data/test_022_pass_category_skills.md
@@ -1,0 +1,22 @@
+Test Better Skills Topics
+=========================
+
+Purpose
+-------
+Test the topics associated with the `Better Skills Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+Publish: preview
+Categories: Skills
+Topics: Online learning, Personal productivity and sustainability
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_022_pass_category_skills.md
+++ b/test_article_metadata/test_data/test_022_pass_category_skills.md
@@ -11,7 +11,7 @@ PASS
 
 
 <!---
-BSSw Metadata
+BSSw Metadata:
 Publish: preview
 Categories: Skills
 Topics: Online learning, Personal productivity and sustainability

--- a/test_article_metadata/test_data/test_022_pass_category_skills.md
+++ b/test_article_metadata/test_data/test_022_pass_category_skills.md
@@ -11,6 +11,7 @@ PASS
 
 
 <!---
+BSSw Metadata
 Publish: preview
 Categories: Skills
 Topics: Online learning, Personal productivity and sustainability

--- a/test_article_metadata/test_data/test_023_pass_category_development_only.md
+++ b/test_article_metadata/test_data/test_023_pass_category_development_only.md
@@ -1,0 +1,22 @@
+Test Better Development Topics
+==============================
+
+Purpose
+-------
+Test the topics associated with the `Better Development Topics` category
+
+Expected Result
+---------------
+PASS
+
+
+<!---
+BSSw Metadata:
+Publish: preview
+Categories: Development
+Tags: training
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+RSS Update: 2019-04-19
+--->

--- a/test_article_metadata/test_data/test_issue-03_01.md
+++ b/test_article_metadata/test_data/test_issue-03_01.md
@@ -9,7 +9,7 @@ This will replace an older setup that looks for the `Publish: yes` entry to dete
 we're in the metadata section.
 
 <!---
-BSSw Metadata   
+BSSw Metadata:   
 Publish: yes
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_issue-03_01.md
+++ b/test_article_metadata/test_data/test_issue-03_01.md
@@ -1,0 +1,20 @@
+### Test Issue #3 - 01
+
+**Dates:** 2019-04-30
+
+Example test to look at adding the "BSSw Metadata" tag as the first line of the metadata
+section and use that in the validator.
+
+This will replace an older setup that looks for the `Publish: yes` entry to determine if 
+we're in the metadata section.
+
+<!---
+BSSw Metadata   
+Publish: yes
+Categories: Planning, Reliability
+Topics: Testing, Debugging, Design
+Tags: training, webinar,
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+--->

--- a/test_article_metadata/test_data/test_issue-03_02.md
+++ b/test_article_metadata/test_data/test_issue-03_02.md
@@ -1,0 +1,18 @@
+### Test Issue #3 - 01
+
+**Dates:** 2019-04-30
+
+Example test to check the `Publish: preview` rule works and kicks off a metadata check.
+
+This test will pass due to correctly formatted metadata.
+
+<!---
+BSSw Metadata   
+Publish: preview
+Categories: Planning, Reliability
+Topics: Testing, Debugging, Design
+Tags: training, webinar,
+Level: 2
+Prerequisites: defaults
+Aggregate: subresource
+--->

--- a/test_article_metadata/test_data/test_issue-03_02.md
+++ b/test_article_metadata/test_data/test_issue-03_02.md
@@ -7,7 +7,7 @@ Example test to check the `Publish: preview` rule works and kicks off a metadata
 This test will pass due to correctly formatted metadata.
 
 <!---
-BSSw Metadata   
+BSSw Metadata:   
 Publish: preview
 Categories: Planning, Reliability
 Topics: Testing, Debugging, Design

--- a/test_article_metadata/test_data/test_issue-03_03.md
+++ b/test_article_metadata/test_data/test_issue-03_03.md
@@ -1,0 +1,18 @@
+### Test Issue #3 - 01
+
+**Dates:** 2019-04-30
+
+Example test to check the `Publish: preview` rule works and kicks off a metadata check.
+
+This test will FAIL due to incorrectly formatted metadata.
+
+<!---
+BSSw Metadata   
+Publish: preview
+Categories: Toga Party!
+Topics: Testing, Debugging, Design
+Tags: training, webinar,
+Level: 2
+Prerequisites: default
+Aggregate: subresource
+--->

--- a/test_article_metadata/test_data/test_pr_0344.md
+++ b/test_article_metadata/test_data/test_pr_0344.md
@@ -8,6 +8,7 @@ should be addressed.
 
 
 <!---
+BSSw Metadata:
 Publish: preview
 Categories: reliability, development
 Topics: testing, continuous integration testing, documentation

--- a/test_article_metadata/test_validate_article.sh
+++ b/test_article_metadata/test_validate_article.sh
@@ -32,10 +32,7 @@ num_tests=0
 num_success=0
 num_failure=0
 
-
 echo ""
-# set -x
-#for file in "${test_articles[@]}"; do
 for ((i=0; i<${#test_articles[@]}; i+=2)); do
     expected_result=${test_articles[i]}
     filename=${test_articles[i+1]}
@@ -66,5 +63,9 @@ echo -e "  Num SUCCESS: ${num_success:?}"
 echo -e "  Num FAILURE: ${num_failure:?}"
 echo -e "==============================="
 
+if [[ ${num_failure:?} != 0 ]]; then
+    echo -e "Tests failed."
+    exit 1
+fi
 
-set +x
+

--- a/test_article_metadata/test_validate_article.sh
+++ b/test_article_metadata/test_validate_article.sh
@@ -22,6 +22,16 @@ test_articles=(
     FAIL    ${test_dir:?}/test_010_fail.md
     FAIL    ${test_dir:?}/test_011_fail.md
     FAIL    ${test_dir:?}/test_012_fail.md
+    PASS    ${test_dir:?}/test_013_pass_category_development.md
+    PASS    ${test_dir:?}/test_014_pass_category_development_deprecated.md
+    PASS    ${test_dir:?}/test_015_pass_category_planning.md
+    PASS    ${test_dir:?}/test_016_pass_category_planning_deprecated.md
+    PASS    ${test_dir:?}/test_017_pass_category_performance.md
+    PASS    ${test_dir:?}/test_018_pass_category_performance_deprecated.md    
+    PASS    ${test_dir:?}/test_019_pass_category_reliability.md    
+    PASS    ${test_dir:?}/test_020_pass_category_collaboration.md    
+    PASS    ${test_dir:?}/test_021_pass_category_collaboration_deprecated.md    
+    PASS    ${test_dir:?}/test_022_pass_category_skills.md    
     FAIL    ${test_dir:?}/test_pr_0344.md
     PASS    ${test_dir:?}/test_issue-03_01.md
     PASS    ${test_dir:?}/test_issue-03_02.md
@@ -41,18 +51,23 @@ for ((i=0; i<${#test_articles[@]}; i+=2)); do
     let "num_tests+=1"
     ${cmd:?} >& /dev/null
     err=$?
+    if [[ "${err:?}" == "0" ]]; then
+        echo -e "Actual : PASS"
+    else
+        echo -e "Actual : FAIL"
+    fi
     if [[ "${expected_result}" == "PASS" ]] && [[ "${err:?}" != "0" ]]; then
         echo -e "${cmd:?}"
         ${cmd:?}
-        echo -e "FAILURE"
+        echo -e "Result : FAILURE"
         let "num_failure+=1"
     elif [[ "${expected_result}" == "FAIL" ]] && [[ "${err:?}" == "0" ]]; then
         echo -e "${cmd:?}"
         ${cmd:?}
-        echo -e "FAILURE"
+        echo -e "Result : FAILURE"
         let "num_failure+=1"
     else
-        echo -e "SUCCESS"
+        echo -e "Result : SUCCESS"
         let "num_success+=1"
     fi
     echo -e ""

--- a/test_article_metadata/test_validate_article.sh
+++ b/test_article_metadata/test_validate_article.sh
@@ -43,10 +43,12 @@ for ((i=0; i<${#test_articles[@]}; i+=2)); do
     err=$?
     if [[ "${expected_result}" == "PASS" ]] && [[ "${err:?}" != "0" ]]; then
         echo -e "${cmd:?}"
+        ${cmd:?}
         echo -e "FAILURE"
         let "num_failure+=1"
     elif [[ "${expected_result}" == "FAIL" ]] && [[ "${err:?}" == "0" ]]; then
         echo -e "${cmd:?}"
+        ${cmd:?}
         echo -e "FAILURE"
         let "num_failure+=1"
     else

--- a/test_article_metadata/test_validate_article.sh
+++ b/test_article_metadata/test_validate_article.sh
@@ -32,6 +32,7 @@ test_articles=(
     PASS    ${test_dir:?}/test_020_pass_category_collaboration.md    
     PASS    ${test_dir:?}/test_021_pass_category_collaboration_deprecated.md    
     PASS    ${test_dir:?}/test_022_pass_category_skills.md    
+    PASS    ${test_dir:?}/test_023_pass_category_development_only.md
     FAIL    ${test_dir:?}/test_pr_0344.md
     PASS    ${test_dir:?}/test_issue-03_01.md
     PASS    ${test_dir:?}/test_issue-03_02.md

--- a/test_article_metadata/test_validate_article.sh
+++ b/test_article_metadata/test_validate_article.sh
@@ -1,32 +1,70 @@
 #!/usr/bin/env bash
 
-debug_flag=""
+debug_flag="-V"
 
 metadata_config=config-metadata.txt
 
 color_tty=""
 color_tty="--color=tty"
 
+test_dir=test_data
+
+test_articles=(
+    FAIL    ${test_dir:?}/test_001_fail.md
+    PASS    ${test_dir:?}/test_002_pass.md
+    PASS    ${test_dir:?}/test_003_pass.md
+    PASS    ${test_dir:?}/test_004_pass.md
+    PASS    ${test_dir:?}/test_005_pass.md
+    PASS    ${test_dir:?}/test_006_pass.md
+    PASS    ${test_dir:?}/test_007_pass.md
+    PASS    ${test_dir:?}/test_008_pass.md
+    PASS    ${test_dir:?}/test_009_pass.md
+    FAIL    ${test_dir:?}/test_010_fail.md
+    FAIL    ${test_dir:?}/test_011_fail.md
+    FAIL    ${test_dir:?}/test_012_fail.md
+    FAIL    ${test_dir:?}/test_pr_0344.md
+    PASS    ${test_dir:?}/test_issue-03_01.md
+    PASS    ${test_dir:?}/test_issue-03_02.md
+    FAIL    ${test_dir:?}/test_issue-03_03.md
+)
+
+num_tests=0
+num_success=0
+num_failure=0
+
+
 echo ""
-python validate_article.py ${debug_flag} -f test_data/test_file_001.md -s ${metadata_config} ${color_tty}
+# set -x
+#for file in "${test_articles[@]}"; do
+for ((i=0; i<${#test_articles[@]}; i+=2)); do
+    expected_result=${test_articles[i]}
+    filename=${test_articles[i+1]}
+    echo -e "Testing: ${expected_result}\t${filename}"
+    cmd="python validate_article.py ${debug_flag} -f ${filename} -s ${metadata_config} ${color_tty}"
+    let "num_tests+=1"
+    ${cmd:?} >& /dev/null
+    err=$?
+    if [[ "${expected_result}" == "PASS" ]] && [[ "${err:?}" != "0" ]]; then
+        echo -e "${cmd:?}"
+        echo -e "FAILURE"
+        let "num_failure+=1"
+    elif [[ "${expected_result}" == "FAIL" ]] && [[ "${err:?}" == "0" ]]; then
+        echo -e "${cmd:?}"
+        echo -e "FAILURE"
+        let "num_failure+=1"
+    else
+        echo -e "SUCCESS"
+        let "num_success+=1"
+    fi
+    echo -e ""
+done
 
 
-echo "================================================================================"
-echo ""
-python validate_article.py ${debug_flag} -f test_data/test_file_002.md -s ${metadata_config} ${color_tty}
+echo -e "==============================="
+echo -e "  Num Tests  : ${num_tests:?}"
+echo -e "  Num SUCCESS: ${num_success:?}"
+echo -e "  Num FAILURE: ${num_failure:?}"
+echo -e "==============================="
 
 
-echo "================================================================================"
-echo ""
-python validate_article.py ${debug_flag} -f test_data/test_file_003.md -s ${metadata_config} ${color_tty}
-
-
-echo "================================================================================"
-echo ""
-python validate_article.py ${debug_flag} -f test_data/test_file_004.md -s ${metadata_config} ${color_tty}
-
-
-echo "================================================================================"
-echo ""
-python validate_article.py ${debug_flag} -f test_data/test_file_005.md -s ${metadata_config} ${color_tty}
-
+set +x

--- a/test_article_metadata/utilities/__init__.py
+++ b/test_article_metadata/utilities/__init__.py
@@ -8,8 +8,10 @@ from colors import colorize
 from colors import get_color
 
 from debug import print_debug
+from debug import print_error
 from debug import print_message
 from debug import print_verbose
+from debug import print_warning
 
 from textfiles import load_textfile_to_stringlist
 

--- a/test_article_metadata/utilities/colors.py
+++ b/test_article_metadata/utilities/colors.py
@@ -10,13 +10,20 @@ colorize(color_name, text, terminal_type) - apply color codes to a text string b
                                             terminal type.
 """
 
-colors = {"none":  "\033[0m",
-          "cyan":  "\033[1;36m",
-          "green": "\033[0;32m",
-          "red":   "\033[0;31m",
-          "yellow": "\033[0;33m",
-          "brightgreen": "\033[1;32m",
+colors = {"none":         "\033[0m",
+          "blue":         "\033[0;34m",
+          "gray":         "\033[0;30m",
+          "cyan":         "\033[1;36m",
+          "green":        "\033[0;32m",
+          "red":          "\033[0;31m",
+          "yellow":       "\033[0;33m",
+          "white":        "\033[0;37m",
+          "brightblue":   "\033[1;34m",
+          "brightgray":   "\033[1;30m",
+          "brightgreen":  "\033[1;32m",
+          "brightred":    "\033[1;31m",
           "brightyellow": "\033[1;33m",
+          "brightwhite":  "\033[1;37m",
           }
 
 

--- a/test_article_metadata/utilities/debug.py
+++ b/test_article_metadata/utilities/debug.py
@@ -18,7 +18,7 @@ def print_debug(text, program_options):
 
     """
     if program_options is not None and program_options.param_log_debug is True:
-        prefix_str = colorize("red", "[D] ", program_options.param_color_stdout)
+        prefix_str = colorize("yellow", "[D] ", program_options.param_color_stdout)
         print "%s%s"%(prefix_str, text)
     return None
 
@@ -53,8 +53,40 @@ def print_message(text, program_options):
                             - 'param_log_debug' : True/False to control whether or not the message is printed.
 
     """
-    prefix_str = colorize("green", "[L] ", program_options.param_color_stdout)
+    prefix_str = colorize("brightgray", "[L] ", program_options.param_color_stdout)
     print "%s%s"%(prefix_str, text)
     return None
 
 
+
+def print_warning(text, program_options):
+    """
+    Prints warning messages.
+
+    @param text: The message text to print out.
+    @param program_options: A program options object (from optparse.OptionParser),
+                            or an object that has the following members:
+                            - 'param_color_stdout' : what kind of colorization is allowed (currently 'tty' or None are allowed).
+                            - 'param_log_debug' : True/False to control whether or not the message is printed.
+
+    """
+    prefix_str = colorize("brightyellow", "[W] ", program_options.param_color_stdout)
+    print "%s%s"%(prefix_str, text)
+    return None
+
+
+
+def print_error(text, program_options):
+    """
+    Prints error messages.
+
+    @param text: The message text to print out.
+    @param program_options: A program options object (from optparse.OptionParser),
+                            or an object that has the following members:
+                            - 'param_color_stdout' : what kind of colorization is allowed (currently 'tty' or None are allowed).
+                            - 'param_log_debug' : True/False to control whether or not the message is printed.
+
+    """
+    prefix_str = colorize("red", "[E] ", program_options.param_color_stdout)
+    print "%s%s"%(prefix_str, text)
+    return None

--- a/test_article_metadata/validate_article.py
+++ b/test_article_metadata/validate_article.py
@@ -82,8 +82,11 @@ def main():
     passed,failmsg = check_metadata_in_file(program_options.param_ifilename, specfile_data, program_options)
 
     if failmsg != "":
-        print "ERROR: "
+        print_message("ERROR: An error was encountered with this file:", program_options)
+        print_message("=== BEGIN ERROR MESSAGE ===", program_options)
         print failmsg
+        print_message("=== END ERROR MESSAGE ===", program_options)
+        print_message("Also, search the output above for additional error or warning messages.", program_options)
 
     s = "Unknown"
     if passed is True:

--- a/test_article_metadata/validate_article.py
+++ b/test_article_metadata/validate_article.py
@@ -84,7 +84,7 @@ def main():
     if failmsg != "":
         print_message("ERROR: An error was encountered with this file:", program_options)
         print_message("=== BEGIN ERROR MESSAGE ===", program_options)
-        print failmsg
+        print_error(failmsg, program_options)
         print_message("=== END ERROR MESSAGE ===", program_options)
         print_message("Also, search the output above for additional error or warning messages.", program_options)
 

--- a/test_article_metadata/validate_article.py
+++ b/test_article_metadata/validate_article.py
@@ -109,3 +109,4 @@ if __name__ == "__main__":
     exit(rvalue)
 
 
+


### PR DESCRIPTION
Working on requests in issue #3 

* `BSSw Metadata` can be used to designate the metadata section.
  * Using the existance of `Preview:` to identify the metadata section is still used but marked as deprecated.  A warning should be printed if we don't find `BSSw Metadata` but we do find the `Publish:` tag.
* Add in `Publish: preview` support to the checker.  If this is present then the metadata will be inspected.
* Updated my silly test driver script to actually run a test against the files in test_data and 
  compare against expected output. IF a test fails then we print out the command line used 
  to run it for replication.

Relates to Issue #3 

@curfman This is probably as far as I'm getting today... but this should be most of the changes needed to the actual script itself... the rest of the changes needed are probably just edits to the `config-metadata.txt` file, but I need some feedback from me comments in #3 and on the gdoc before proceeding with the edits to that file.

I won't merge this until we get all the changes in #3 addressed.